### PR TITLE
style: improve table appearance

### DIFF
--- a/src/app/(dashboard)/components/datacap-over-time-chart.tsx
+++ b/src/app/(dashboard)/components/datacap-over-time-chart.tsx
@@ -186,8 +186,7 @@ const Component = ({ data, allocators }: Props) => {
         )}
         <div
           className={cn(
-            "flex flex-col gap-x-1 h-full max-h-[900px] w-[250px]",
-            mode === "allocator" && "overflow-y-auto"
+            "flex flex-col gap-x-1 h-full max-h-[900px] w-[250px] overflow-y-auto"
           )}
         >
           {reversedValueKeys.map((entry, index) => {

--- a/src/app/(dashboard)/components/stats.tsx
+++ b/src/app/(dashboard)/components/stats.tsx
@@ -24,7 +24,7 @@ const Component = async () => {
         <CardContent>
           <div className="w-full flex justify-between">
             <p className="font-semibold textxl">{stats?.numberOfAllocators}</p>
-            <StatsLink href="/allocators">Allocators</StatsLink>
+            <StatsLink href="/allocators?showInactive=true&page=1">Allocators</StatsLink>
           </div>
         </CardContent>
       </Card>

--- a/src/app/(dashboard)/hooks/useDataCapOverTimeChart.tsx
+++ b/src/app/(dashboard)/hooks/useDataCapOverTimeChart.tsx
@@ -23,10 +23,14 @@ export const useDataCapOverTimeChart = (
   const [valueKeys, setValueKeys] = useState<string[]>([]);
   const [selectedValues, setSelectedValues] = useState<string[]>([]);
 
-  const reversedValueKeys = useMemo(
-    () => valueKeys.slice().reverse(),
-    [valueKeys]
-  );
+  const reversedValueKeys = useMemo(() => {
+    const sortedValueKeys = valueKeys.slice().sort((a, b) => {
+      const weekA = parseInt(a.substring(1));
+      const weekB = parseInt(b.substring(1));
+      return weekA - weekB;
+    });
+    return sortedValueKeys.reverse(); 
+  }, [valueKeys]);
 
   const valuesToDisplay = useMemo(() => {
     if (!selectedValues?.length) {

--- a/src/app/allocators/components/useAllocatorsColumns.tsx
+++ b/src/app/allocators/components/useAllocatorsColumns.tsx
@@ -178,9 +178,9 @@ export function useAllocatorsColumns({
                   className="text-muted-foreground cursor-help"
                 />
               </HoverCardTrigger>
-              <HoverCardContent className="w-32">
-                <p>Block height</p>
-                <p>{createdAtHeight}</p>
+              <HoverCardContent className="w-32 flex flex-col gap-1 justify-center items-center">
+                <span>Block height</span>
+                <span>{createdAtHeight}</span>
               </HoverCardContent>
             </HoverCard>
           </div>
@@ -250,13 +250,14 @@ export function useAllocatorsColumns({
                 <HoverCardContent className="w-64">
                   {allowanceArray.map((allowance, index) => {
                     return (
-                      <div key={index} className="grid grid-cols-7 gap-2">
-                        <div className="col-span-2 text-right">
-                          {convertBytesToIEC(allowance.allowance)}
-                        </div>
-                        <div className="col-span-5 text-sm text-muted-foreground">
+                      <div
+                        key={index}
+                        className="flex items-center gap-3 justify-center"
+                      >
+                        <span>{convertBytesToIEC(allowance.allowance)}</span>
+                        <span className="text-sm text-muted-foreground">
                           ({calculateDateFromHeight(+allowance.height)})
-                        </div>
+                        </span>
                       </div>
                     );
                   })}

--- a/src/app/clients/components/clients-list.tsx
+++ b/src/app/clients/components/clients-list.tsx
@@ -54,11 +54,19 @@ const ClientsList = ({ clients, params }: ClientsListProps) => {
         />
         <CardContent className="p-0 m-0 border-b bg-[#F2F9FF]">
           <div className="flex items-center px-6 py-2 gap-3">
-            <InfoIcon className="w-5 h-5 bg-[#475A6E] rounded-full text-white flex flex-col items-center justify-center" />
+            <InfoIcon className="w-5 h-5 flex-shrink-0 bg-[#475A6E] rounded-full text-white flex flex-col items-center justify-center" />
             <p className="text-sm">
-              Note: Clients that receive automatic DataCap allocations from the
-              verify.glif.io site maintained by the Infinite Scroll allocator
-              are marked as &quot;Glif auto verified.&quot;
+              Note: Clients that receive automatic DataCap allocations from the{" "}
+              <a
+                href="https://verify.glif.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600"
+              >
+                verify.glif.io
+              </a>{" "}
+              site maintained by the Infinite Scroll allocator are marked as
+              &quot;Glif auto verified.&quot;
             </p>
           </div>
         </CardContent>


### PR DESCRIPTION
## Description 
This PR addresses issues related to tables in the application. The main focus is on fixing table-related bugs and improving their appearance.

## Fixes
- When users click the button on the first card, it direct them to the Allocators page with the "Show Inactive" checkbox selected, as the card title is "Total Approved Allocators".
- Reordered the weeks on `DataCap Used Over Time by Allocator` **when `Week` tab selected to display the most recent at the top
- Fixed overflow for the `DataCap Used Over Time by Allocator` **when `Allocator` tab selected
- Fixed "squashing" of the info icon on `Client` page
- Fixed alignment in the popover elements in the tables

As as reference, [here is the UXIT Dogfooding Report. ](https://www.notion.so/filecoin/DataCap-Stats-Dashboard-Report-1197631f282580ce8e5bc0084f2440ea)